### PR TITLE
Fix error in documentation of QL

### DIFF
--- a/src/ql.jl
+++ b/src/ql.jl
@@ -28,8 +28,8 @@ The object has two fields:
   - The lower triangular part contains the elements of ``L``, that is `L =
     tril(F.factors)` for a `QL` object `F`.
 
-  - The subdiagonal part contains the reflectors ``v_i`` stored in a packed format where
-    ``v_i`` is the ``i``th column of the matrix `V = I + tril(F.factors, -1)`.
+  - The superdiagonal part contains the reflectors ``v_i`` stored in a packed format where
+    ``v_i`` is the ``i``th column of the matrix `V = I + triu(F.factors, 1)`.
 
 * `τ` is a vector  of length `min(m,n)` containing the coefficients ``\tau_i``.
 


### PR DESCRIPTION
This PR fixes an error in the documentation of QL.

Unless I am just confusing myself here, I am quite certain the documentation here was incorrect. Even just on the surface, it makes no sense that the lower triangular and subdiagonal simultaneously store L and Q. It is actually being stored in the superdiagonal...

```julia
julia> A = [1 5 4; 2 4 2; 1 1 2]
3×3 Matrix{Int64}:
 1  5  4
 2  4  2
 1  1  2

julia> F = ql(A)
MatrixFactorizations.QL{Float64, Matrix{Float64}, Vector{Float64}}
Q factor:
3×3 MatrixFactorizations.QLPackedQ{Float64, Matrix{Float64}, Vector{Float64}}:
  0.57735   2.77556e-16  -0.816497
 -0.57735  -0.707107     -0.408248
 -0.57735   0.707107     -0.408248
L factor:
3×3 Matrix{Float64}:
 -1.1547     0.0       0.0
 -0.707107  -2.12132   0.0
 -2.04124   -6.12372  -4.89898

julia> τ = F.τ
3-element Vector{Float64}:
 0.0
 1.9120955864630138
 1.4082482904638631

julia> v = I + triu(F.factors,1)
3×3 Matrix{Float64}:
 1.0  0.214413  0.579796
 0.0  1.0       0.289898
 0.0  0.0       1.0

julia> (I-τ[3]*v[:,3]*v[:,3]')*(I-τ[2]*v[:,2]*v[:,2]')*(I-τ[1]*v[:,1]*v[:,1]') ≈ F.Q
true
```