### PR TITLE
Update docs for polar() keyword argument, it is alg (not algorithm)

### DIFF
--- a/src/polar.jl
+++ b/src/polar.jl
@@ -4,7 +4,7 @@
 export polar, PolarDecomposition
 
 """
-    polar(A; algorithm::Symbol, maxiter, tol, verbose)
+    polar(A; alg::Symbol, maxiter, tol, verbose)
 
 Compute the polar decomposition of the matrix `A`.
 
@@ -12,7 +12,7 @@ Returns a [`PolarDecomposition`](@ref).
 
 Arguments:
 
-`algorithm` (default: `:newton`) may be one of:
+`alg` (default: `:newton`) may be one of:
 - ``:newton``: scaled Newton's method
 - ``:qdwh``: the QR-based Dynamically weighted Halley (QDWH) method
 - ``:halley``: Halley's method


### PR DESCRIPTION
As coded here
https://github.com/JuliaLinearAlgebra/MatrixFactorizations.jl/blob/v3.0.1/src/polar.jl#L572-L573
```
function polar(A::AbstractMatrix{T};
                   alg::Symbol=:newton,
```
also tests are written with keyword `alg`, not `algorithm`.