### PR TITLE
Add the A = LUL⁻¹ factorization

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MatrixFactorizations"
 uuid = "a3b82374-2e81-5b9e-98ce-41277c0e4c87"
-version = "3.1"
+version = "3.1.1"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/MatrixFactorizations.jl
+++ b/src/MatrixFactorizations.jl
@@ -1,6 +1,6 @@
 module MatrixFactorizations
 using Base, LinearAlgebra, ArrayLayouts
-import Base: axes, axes1, getproperty, iterate, tail, oneto
+import Base: axes, axes1, getproperty, propertynames, iterate, tail, oneto
 import LinearAlgebra: BlasInt, BlasReal, BlasFloat, BlasComplex, axpy!,
    copy_oftype, checksquare, adjoint, transpose, AdjOrTrans, HermOrSym,
    det, logdet, logabsdet, isposdef
@@ -8,7 +8,7 @@ import LinearAlgebra.LAPACK: chkuplo, chktrans
 import LinearAlgebra: cholesky, cholesky!, norm, diag, eigvals!, eigvals, eigen!, eigen,
    qr, axpy!, ldiv!, rdiv!, mul!, lu, lu!, ldlt, ldlt!, AbstractTriangular, inv,
    chkstride1, kron, lmul!, rmul!, factorize, StructuredMatrixStyle, det, logabsdet,
-   AbstractQ, _zeros, _cut_B, _ret_size, require_one_based_indexing, checksquare,
+   AbstractQ, _zeros, _cut_B, _ret_size, require_one_based_indexing,
    checknonsingular, ipiv2perm, copytri!, issuccess, RealHermSymComplexHerm,
    cholcopy, checkpositivedefinite, char_uplo, copymutable_oftype, copy_similar, choltype
 
@@ -32,8 +32,9 @@ import ArrayLayouts: reflector!, reflectorApply!, materialize!, @_layoutlmul, @_
    layout_getindex, rowsupport, colsupport
 
 
-export ul, ul!, ql, ql!, qrunblocked, qrunblocked!, UL, QL, reversecholesky, reversecholesky!, ReverseCholesky
-
+export ul, ul!, ql, ql!, qrunblocked, qrunblocked!, UL, QL,
+    reversecholesky, reversecholesky!, ReverseCholesky,
+    lulinv, lulinv!, LULinv
 
 const AdjointQtype = isdefined(LinearAlgebra, :AdjointQ) ? LinearAlgebra.AdjointQ : Adjoint
 const AbstractQtype = AbstractQ <: AbstractMatrix ? AbstractMatrix : AbstractQ
@@ -123,5 +124,6 @@ include("ql.jl")
 include("rq.jl")
 include("polar.jl")
 include("reversecholesky.jl")
+include("lulinv.jl")
 
 end #module

--- a/src/choleskyinv.jl
+++ b/src/choleskyinv.jl
@@ -23,7 +23,7 @@ end
  factorization.
 
  The two factorizations are obtained in one pass and this is faster
- then calling Julia's [chelosky](https://docs.julialang.org/en/v1/stdlib/LinearAlgebra/#LinearAlgebra.cholesky)
+ then calling Julia's [cholesky](https://docs.julialang.org/en/v1/stdlib/LinearAlgebra/#LinearAlgebra.cholesky)
  function and inverting the lower factor for small matrices.
 
  Input matrix `P` may be of type `Matrix` or `Hermitian`. Since only the
@@ -118,7 +118,7 @@ function choleskyinv!(P::Matrix{T};
 			tol::Real = √eps(real(T))) where T<:Union{Real, Complex}
 	LinearAlgebra.require_one_based_indexing(P)
 	n = LinearAlgebra.checksquare(P)
-	
+
 	@inbounds for j=1:n-1
 		check && abs2(P[j, j])<tol && throw(LinearAlgebra.PosDefException(1))
 		for i=j+1:n

--- a/src/lulinv.jl
+++ b/src/lulinv.jl
@@ -6,10 +6,10 @@ is the return type of [`lulinv`](@ref), the corresponding matrix factorization f
 
 The individual components of the factorization `F::LULinv` can be accessed via [`getproperty`](@ref):
 
-| Component | Description                              |
-|:----------|:-----------------------------------------|
-| `F.L`     | `L` (unit lower triangular) part of `UL` |
-| `F.U`     | `U` (upper triangular) part of `UL`      |
+| Component | Description                                 |
+|:----------|:--------------------------------------------|
+| `F.L`     | `L` (unit lower triangular) part of `LUL⁻¹` |
+| `F.U`     | `U` (upper triangular) part of `LUL⁻¹`      |
 
 Iterating the factorization produces the components `F.L` and `F.U`.
 

--- a/src/lulinv.jl
+++ b/src/lulinv.jl
@@ -1,0 +1,203 @@
+"""
+    LULinv <: Factorization
+
+Matrix factorization type of the `LUL⁻¹` factorization of a square matrix `A`. This
+is the return type of [`lulinv`](@ref), the corresponding matrix factorization function.
+
+The individual components of the factorization `F::LULinv` can be accessed via [`getproperty`](@ref):
+
+| Component | Description                              |
+|:----------|:-----------------------------------------|
+| `F.L`     | `L` (unit lower triangular) part of `UL` |
+| `F.U`     | `U` (upper triangular) part of `UL`      |
+
+Iterating the factorization produces the components `F.L` and `F.U`.
+
+# Examples
+```jldoctest
+julia> A = [4 3; 6 3]
+2×2 Array{Int64,2}:
+ 4  3
+ 6  3
+
+julia> F = lulinv(A)
+LULinv{Float64, Matrix{Float64}}
+L factor:
+2×2 Matrix{Float64}:
+  1.0      0.0
+ -1.59067  1.0
+U factor:
+2×2 Matrix{Float64}:
+ -0.772002  3.0
+  0.0       7.772
+
+julia> F.L * F.U / F.L ≈ A
+true
+
+julia> l, u = lulinv(A); # destructuring via iteration
+
+julia> l == F.L && u == F.U
+true
+
+julia> A = [-150 334 778; -89 195 464; 5 -10 -27]
+3×3 Matrix{Int64}:
+ -150  334  778
+  -89  195  464
+    5  -10  -27
+
+julia> F = lulinv(A, [17, -2, 3//1]) # can input rational eigenvalues directly
+LULinv{Rational{Int64}, Matrix{Rational{Int64}}}
+L factor:
+3×3 Matrix{Rational{Int64}}:
+  1      0    0
+ 1//2    1    0
+  0    -2//5  1
+U factor:
+3×3 Matrix{Rational{Int64}}:
+ 17  114//5  778
+  0    -2     75
+  0     0      3
+
+julia> F.L * F.U / F.L == A
+true
+```
+"""
+struct LULinv{T, S <: AbstractMatrix{T}} <: Factorization{T}
+    factors::S
+    function LULinv{T, S}(factors) where {T, S <: AbstractMatrix{T}}
+        require_one_based_indexing(factors)
+        new{T, S}(factors)
+    end
+end
+
+
+LULinv(factors::AbstractMatrix{T}) where T = LULinv{T, typeof(factors)}(factors)
+LULinv{T}(factors::AbstractMatrix) where T = LULinv(convert(AbstractMatrix{T}, factors))
+
+iterate(F::LULinv) = (F.L, Val(:U))
+iterate(F::LULinv, ::Val{:U}) = (F.U, Val(:done))
+iterate(F::LULinv, ::Val{:done}) = nothing
+
+
+function lulinvtype(T::Type)
+    # In generic_ulfact!, the elements of the lower part of the matrix are
+    # obtained using the division of two matrix elements. Hence their type can
+    # be different (e.g. the division of two types with the same unit is a type
+    # without unit).
+    # The elements of the upper part are obtained by U - L * U / L
+    # where U is an upper part element and L is a lower part element.
+    # Therefore, the types LT, UT should be invariant under the map:
+    # (LT, UT) -> begin
+    #     L = oneunit(UT) / oneunit(UT)
+    #     U = oneunit(UT) - L * oneunit(UT) / L
+    #     typeof(L), typeof(U)
+    # end
+    # The following should handle most cases
+    UT = typeof(oneunit(T) - (oneunit(T) / (oneunit(T) + zero(T)) * oneunit(T) * (oneunit(T) + zero(T)) / oneunit(T)))
+    LT = typeof(oneunit(UT) / oneunit(UT))
+    S = promote_type(T, LT, UT)
+end
+
+
+size(A::LULinv)    = size(getfield(A, :factors))
+size(A::LULinv, i) = size(getfield(A, :factors), i)
+
+function getL(F::LULinv{T}) where T
+    n = size(F.factors, 1)
+    L = tril!(getindex(getfield(F, :factors), 1:n, 1:n))
+    for i in 1:n L[i, i] = one(T) end
+    return L
+end
+
+function getU(F::LULinv)
+    n = size(F.factors, 1)
+    triu!(getindex(getfield(F, :factors), 1:n, 1:n))
+end
+
+function getproperty(F::LULinv{T, <: AbstractMatrix}, d::Symbol) where T
+    if d === :L
+        return getL(F)
+    elseif d === :U
+        return getU(F)
+    else
+        getfield(F, d)
+    end
+end
+
+propertynames(F::LULinv, private::Bool=false) =
+    (:L, :U, (private ? fieldnames(typeof(F)) : ())...)
+
+function show(io::IO, mime::MIME{Symbol("text/plain")}, F::LULinv)
+    summary(io, F); println(io)
+    println(io, "L factor:")
+    show(io, mime, F.L)
+    println(io, "\nU factor:")
+    show(io, mime, F.U)
+end
+
+
+lulinv(A::AbstractMatrix; kwds...) = lulinv(A, eigvals(A); kwds...)
+function lulinv(A::AbstractMatrix{T}, λ::AbstractVector{T}; kwds...) where T
+    S = lulinvtype(T)
+    lulinv!(copy_oftype(A, S), copy_oftype(λ, S); kwds...)
+end
+function lulinv(A::AbstractMatrix{T1}, λ::AbstractVector{T2}; kwds...) where {T1, T2}
+    T = promote_type(T1, T2)
+    S = lulinvtype(T)
+    lulinv!(copy_oftype(A, S), copy_oftype(λ, S); kwds...)
+end
+
+function lulinv!(A::Matrix{T}, λ::Vector{T}; rtol::Real = size(A, 1)*eps(real(float(oneunit(T))))) where T
+    n = checksquare(A)
+    n == length(λ) || throw(ArgumentError("Eigenvalue count does not match matrix dimensions."))
+    v = zeros(T, n)
+    for i in 1:n-1
+        # We must find an eigenvector with nonzero "first" entry. A failed UL factorization of A-λI reveals this vector provided L₁₁ == 0.
+        for j in 1:length(λ)
+            F = ul!(view(A, i:n, i:n) - λ[j]*I; check=false)
+            nrm = norm(F.L)
+            if norm(F.L[1]) ≤ rtol*nrm # v[i] is a free parameter; we set it to 1.
+                fill!(v, zero(T))
+                v[i] = one(T)
+                # Next, we must scan the remaining free parameters, set them to 0, so that we find a nonsingular lower-triangular linear system for the nontrivial remaining part of the eigenvector.
+                idx = Int[]
+                for k in 2:n+1-i
+                    if norm(F.L[k, k]) > rtol*nrm
+                        push!(idx, k)
+                    end
+                end
+                v[idx.+(i-1)] .= -F.L[idx, 1]
+                ldiv!(LowerTriangular(view(F.L, idx, idx)), view(v, idx.+(i-1)))
+                deleteat!(λ, j)
+                break
+            end
+        end
+        for k in 1:n
+            for j in i+1:n
+                A[k, i] += A[k, j]*v[j]
+            end
+        end
+        for j in i:n
+            for k in i+1:n
+                A[k, j] -= A[i, j]*v[k]
+            end
+        end
+        for k in i+1:n
+            A[k, i] = v[k]
+        end
+    end
+    return LULinv(A)
+end
+
+function ldiv!(F::LULinv, B::AbstractVecOrMat)
+    L = UnitLowerTriangular(F.factors)
+    return lmul!(L, ldiv!(UpperTriangular(F.factors), ldiv!(L, B)))
+end
+
+function rdiv!(B::AbstractVecOrMat, F::LULinv)
+    L = UnitLowerTriangular(F.factors)
+    return rdiv!(rdiv!(rmul!(B, L), UpperTriangular(F.factors)), L)
+end
+
+det(F::LULinv) = det(UpperTriangular(F.factors))
+logabsdet(F::LULinv) = logabsdet(UpperTriangular(F.factors))

--- a/src/lulinv.jl
+++ b/src/lulinv.jl
@@ -73,6 +73,7 @@ end
 
 LULinv(factors::AbstractMatrix{T}) where T = LULinv{T, typeof(factors)}(factors)
 LULinv{T}(factors::AbstractMatrix) where T = LULinv(convert(AbstractMatrix{T}, factors))
+LULinv{T}(F::LULinv) where T = LULinv{T}(F.factors)
 
 iterate(F::LULinv) = (F.L, Val(:U))
 iterate(F::LULinv, ::Val{:U}) = (F.U, Val(:done))
@@ -166,8 +167,10 @@ function lulinv!(A::Matrix{T}, λ::Vector{T}; rtol::Real = size(A, 1)*eps(real(f
                         push!(idx, k)
                     end
                 end
-                v[idx.+(i-1)] .= -F.L[idx, 1]
-                ldiv!(LowerTriangular(view(F.L, idx, idx)), view(v, idx.+(i-1)))
+                if !isempty(idx)
+                    v[idx.+(i-1)] .= -F.L[idx, 1]
+                    ldiv!(LowerTriangular(view(F.L, idx, idx)), view(v, idx.+(i-1)))
+                end
                 deleteat!(λ, j)
                 break
             end

--- a/src/polar.jl
+++ b/src/polar.jl
@@ -65,9 +65,9 @@ function PolarDecomposition{T}(U::AbstractArray{T}, H::AbstractArray{T}, niter=1
     PolarDecomposition{T,typeof(U),typeof(H)}(U,H,niter,converged)
 end
 
-Base.iterate(P::PolarDecomposition) = (P.U, Val(:U))
-Base.iterate(P::PolarDecomposition, ::Val{:U}) = (P.H, Val(:done))
-Base.iterate(P::PolarDecomposition, ::Val{:done}) = nothing
+iterate(P::PolarDecomposition) = (P.U, Val(:U))
+iterate(P::PolarDecomposition, ::Val{:U}) = (P.H, Val(:done))
+iterate(P::PolarDecomposition, ::Val{:done}) = nothing
 
 module Polar
 using LinearAlgebra

--- a/src/ql.jl
+++ b/src/ql.jl
@@ -49,9 +49,9 @@ function QL{T}(factors::AbstractMatrix, τ::AbstractVector) where {T}
 end
 
 # iteration for destructuring into components
-Base.iterate(S::QL) = (S.Q, Val(:L))
-Base.iterate(S::QL, ::Val{:L}) = (S.L, Val(:done))
-Base.iterate(S::QL, ::Val{:done}) = nothing
+iterate(S::QL) = (S.Q, Val(:L))
+iterate(S::QL, ::Val{:L}) = (S.L, Val(:done))
+iterate(S::QL, ::Val{:done}) = nothing
 
 function generic_qlfactUnblocked!(A::AbstractMatrix{T}) where {T}
     require_one_based_indexing(A)
@@ -211,7 +211,7 @@ function show(io::IO, mime::MIME{Symbol("text/plain")}, F::QL)
     show(io, mime, F.L)
 end
 
-@inline function getL(F::QL, _) 
+@inline function getL(F::QL, _)
     m, n = size(F)
     tril!(getfield(F, :factors)[end-min(m,n)+1:end, 1:n], max(n-m,0))
 end
@@ -233,7 +233,7 @@ function getproperty(F::QL, d::Symbol)
     end
 end
 
-Base.propertynames(F::QL, private::Bool=false) =
+propertynames(F::QL, private::Bool=false) =
     (:L, :Q, (private ? fieldnames(typeof(F)) : ())...)
 
 
@@ -295,20 +295,20 @@ abstract type AbstractQLLayout <: MemoryLayout end
 """
     QLPackedLayout{SLAY,TLAY}()
 
-represents a Packed QL factorization whose 
+represents a Packed QL factorization whose
 factors are stored with layout SLAY and τ stored with layout TLAY
 """
 struct QLPackedLayout{SLAY,TLAY} <: AbstractQLLayout end
 struct QLPackedQLayout{SLAY,TLAY} <: AbstractQLayout end
 struct AdjQLPackedQLayout{SLAY,TLAY} <: AbstractQLayout end
 
-MemoryLayout(::Type{<:QL{<:Any,Mat,Tau}}) where {Mat,Tau} = 
+MemoryLayout(::Type{<:QL{<:Any,Mat,Tau}}) where {Mat,Tau} =
     QLPackedLayout{typeof(MemoryLayout(Mat)),typeof(MemoryLayout(Tau))}()
 
 
 adjointlayout(::Type, ::QLPackedQLayout{SLAY,TLAY}) where {SLAY,TLAY} = AdjQLPackedQLayout{SLAY,TLAY}()
 
-MemoryLayout(::Type{<:QLPackedQ{<:Any,Mat,Tau}}) where {Mat,Tau} = 
+MemoryLayout(::Type{<:QLPackedQ{<:Any,Mat,Tau}}) where {Mat,Tau} =
     QLPackedQLayout{typeof(MemoryLayout(Mat)),typeof(MemoryLayout(Tau))}()
 
 colsupport(::QLPackedQLayout, Q, j) = minimum(colsupport(Q.factors, j)):size(Q,1)
@@ -378,7 +378,7 @@ end
 
 
 ### QBc/QcBc
-function materialize!(M::Rmul{<:Any,<:QLPackedQLayout}) 
+function materialize!(M::Rmul{<:Any,<:QLPackedQLayout})
     A,Q = M.A, M.B
     mQ, nQ = size(Q.factors)
     mA, nA = size(A,1), size(A,2)
@@ -406,8 +406,8 @@ function materialize!(M::Rmul{<:Any,<:QLPackedQLayout})
 end
 
 ### AQc
-function materialize!(M::Rmul{<:Any,<:AdjQLPackedQLayout}) 
-    A,adjQ = M.A, M.B    
+function materialize!(M::Rmul{<:Any,<:AdjQLPackedQLayout})
+    A,adjQ = M.A, M.B
     Q = parent(adjQ)
     mQ, nQ = size(Q.factors)
     mA, nA = size(A,1), size(A,2)
@@ -525,5 +525,3 @@ function (\)(A::QL{T}, BIn::VecOrMat{Complex{T}}) where T<:BlasReal
     XX = reshape(collect(reinterpret(Complex{T}, copy(transpose(reshape(X, div(length(X), 2), 2))))), _ret_size(A, BIn))
     return _cut_B(XX, 1:n)
 end
-
-

--- a/src/qr.jl
+++ b/src/qr.jl
@@ -52,9 +52,9 @@ QR{T}(factors::AbstractMatrix, τ::AbstractVector) where {T} =
 QR(F::LinearAlgebra.QR) = QR(F.factors, F.τ)
 
 # iteration for destructuring into components
-Base.iterate(S::QR) = (S.Q, Val(:R))
-Base.iterate(S::QR, ::Val{:R}) = (S.R, Val(:done))
-Base.iterate(S::QR, ::Val{:done}) = nothing
+iterate(S::QR) = (S.Q, Val(:R))
+iterate(S::QR, ::Val{:R}) = (S.R, Val(:done))
+iterate(S::QR, ::Val{:done}) = nothing
 
 
 function _qrfactUnblocked!(_, _, A::AbstractMatrix{T}, τ::AbstractVector) where {T}
@@ -138,7 +138,7 @@ function getproperty(F::QR, d::Symbol)
     end
 end
 
-Base.propertynames(F::QR, private::Bool=false) =
+propertynames(F::QR, private::Bool=false) =
     (:R, :Q, (private ? fieldnames(typeof(F)) : ())...)
 
 ldiv!(F::QR, B::AbstractVecOrMat) = ArrayLayouts.ldiv!(F, B)

--- a/src/reversecholesky.jl
+++ b/src/reversecholesky.jl
@@ -34,9 +34,9 @@ ReverseCholesky(U::UpperTriangular{T}) where {T} = ReverseCholesky{T,typeof(U.da
 ReverseCholesky(L::LowerTriangular{T}) where {T} = ReverseCholesky{T,typeof(L.data)}(L.data, 'L', 0)
 
 # iteration for destructuring into components
-Base.iterate(C::ReverseCholesky) = (C.U, Val(:U))
-Base.iterate(C::ReverseCholesky, ::Val{:U}) = (C.L, Val(:done))
-Base.iterate(C::ReverseCholesky, ::Val{:done}) = nothing
+iterate(C::ReverseCholesky) = (C.U, Val(:U))
+iterate(C::ReverseCholesky, ::Val{:U}) = (C.L, Val(:done))
+iterate(C::ReverseCholesky, ::Val{:done}) = nothing
 
 ## Non BLAS/LAPACK element types (generic)
 function reversecholesky_layout!(_, A::AbstractMatrix, ::Type{UpperTriangular})
@@ -230,7 +230,7 @@ function getproperty(C::ReverseCholesky, d::Symbol)
         return getfield(C, d)
     end
 end
-Base.propertynames(F::ReverseCholesky, private::Bool=false) =
+propertynames(F::ReverseCholesky, private::Bool=false) =
     (:U, :L, :UL, (private ? fieldnames(typeof(F)) : ())...)
 
 

--- a/src/rq.jl
+++ b/src/rq.jl
@@ -49,14 +49,14 @@ function RQ{T}(factors::AbstractMatrix, τ::AbstractVector) where {T}
 end
 
 # iteration for destructuring into components
-Base.iterate(S::RQ) = (S.R, Val(:Q))
-Base.iterate(S::RQ, ::Val{:Q}) = (S.Q, Val(:done))
-Base.iterate(S::RQ, ::Val{:done}) = nothing
+iterate(S::RQ) = (S.R, Val(:Q))
+iterate(S::RQ, ::Val{:Q}) = (S.Q, Val(:done))
+iterate(S::RQ, ::Val{:done}) = nothing
 
-Base.size(F::RQ, dim::Integer) = size(getfield(F, :factors), dim)
-Base.size(F::RQ) = size(getfield(F, :factors))
+size(F::RQ, dim::Integer) = size(getfield(F, :factors), dim)
+size(F::RQ) = size(getfield(F, :factors))
 
-function Base.getproperty(F::RQ, d::Symbol)
+function getproperty(F::RQ, d::Symbol)
     m, n = size(F)
     if d === :R
         if m <= n
@@ -95,7 +95,7 @@ AbstractArray(F::RQ) = AbstractMatrix(F)
 Matrix(F::RQ) = Array(AbstractArray(F))
 Array(F::RQ) = Matrix(F)
 
-function Base.show(io::IO, mime::MIME{Symbol("text/plain")}, F::RQ)
+function show(io::IO, mime::MIME{Symbol("text/plain")}, F::RQ)
     summary(io, F); println(io)
     println(io, "R factor:")
     show(io, mime, F.R)
@@ -124,8 +124,8 @@ AbstractQ{T}(Q::RQPackedQ) where {T} = RQPackedQ{T}(Q)
 convert(::Type{AbstractQ{T}}, Q::RQPackedQ) where {T} = RQPackedQ{T}(Q)
 AbstractMatrix{T}(Q::RQPackedQ) where {T} = Matrix{T}(Q)
 
-Base.size(Q::RQPackedQ, dim::Integer) = size(getfield(Q, :factors), dim == 1 ? 2 : dim)
-Base.size(Q::RQPackedQ) = size(Q, 1), size(Q, 2)
+size(Q::RQPackedQ, dim::Integer) = size(getfield(Q, :factors), dim == 1 ? 2 : dim)
+size(Q::RQPackedQ) = size(Q, 1), size(Q, 2)
 
 function lmul!(A::RQPackedQ{T,<:StridedMatrix}, B::StridedVecOrMat{T}) where {T<:BlasFloat}
     m,n = size(A.factors)

--- a/src/ul.jl
+++ b/src/ul.jl
@@ -1,4 +1,4 @@
-# This file is based on JuliaLang/LinearAlgebra/src/lu.jl, a part of Julia. 
+# This file is based on JuliaLang/LinearAlgebra/src/lu.jl, a part of Julia.
 # License is MIT: https://julialang.org/license
 
 ####################
@@ -75,10 +75,10 @@ end
 
 
 # iteration for destructuring into components
-Base.iterate(S::UL) = (S.U, Val(:L))
-Base.iterate(S::UL, ::Val{:L}) = (S.L, Val(:p))
-Base.iterate(S::UL, ::Val{:p}) = (S.p, Val(:done))
-Base.iterate(S::UL, ::Val{:done}) = nothing
+iterate(S::UL) = (S.U, Val(:L))
+iterate(S::UL, ::Val{:L}) = (S.L, Val(:p))
+iterate(S::UL, ::Val{:p}) = (S.p, Val(:done))
+iterate(S::UL, ::Val{:done}) = nothing
 
 if isdefined(LinearAlgebra, :AdjointFactorization) # VERSION >= v"1.10-"
     adjoint(F::UL{<:Real}) = LinearAlgebra.TransposeFactorization(F)
@@ -291,7 +291,7 @@ end
 
 const _ul = ul_layout
 
-ul(A::AbstractMatrix{T}, pivot::Union{Val{false}, Val{true}}=Val(true); check::Bool = true) where T = 
+ul(A::AbstractMatrix{T}, pivot::Union{Val{false}, Val{true}}=Val(true); check::Bool = true) where T =
     _ul(MemoryLayout(A), A, pivot; check=check)
 
 ul(S::UL) = S
@@ -323,7 +323,7 @@ function getU(F::UL{T}, _) where T
 end
 
 getL(F::UL) = getL(F, size(F.factors))
-function getL(F::UL, _) 
+function getL(F::UL, _)
     m, n = size(F)
     tril!(layout_getindex(getfield(F, :factors),1:min(m,n),1:n))
 end
@@ -343,7 +343,7 @@ function getproperty(F::UL{T,<:AbstractMatrix}, d::Symbol) where T
     end
 end
 
-Base.propertynames(F::UL, private::Bool=false) =
+propertynames(F::UL, private::Bool=false) =
     (:L, :U, :p, :P, (private ? fieldnames(typeof(F)) : ())...)
 
 issuccess(F::UL) = F.info == 0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,5 +36,6 @@ include("test_ql.jl")
 include("test_rq.jl")
 include("test_polar.jl")
 include("test_reversecholesky.jl")
+include("test_lulinv.jl")
 
 include("test_banded.jl")

--- a/test/test_lulinv.jl
+++ b/test/test_lulinv.jl
@@ -86,19 +86,19 @@ using LinearAlgebra, MatrixFactorizations, Random, Test
     end
     @testset "REPL printing" begin
             bf = IOBuffer()
-            show(bf, "text/plain", lulinv([2 1; 1 2]))
+            show(bf, "text/plain", lulinv([1 0; 0 1]))
             seekstart(bf)
             @test String(take!(bf)) ==
 """
 LULinv{Float64, Matrix{Float64}}
 L factor:
 2×2 Matrix{Float64}:
-  1.0  0.0
- -1.0  1.0
+ 1.0  0.0
+ 0.0  1.0
 U factor:
 2×2 Matrix{Float64}:
- 1.0  1.0
- 0.0  3.0"""
+ 1.0  0.0
+ 0.0  1.0"""
     end
     @testset "propertynames" begin
         names = sort!(collect(string.(Base.propertynames(lulinv([2 1; 1 2])))))
@@ -110,5 +110,7 @@ U factor:
         A = [-150 334 778; -89 195 464; 5 -10 -27]
         F = lulinv(A, [17, -2, 3//1])
         @test A * F.L == F.L * F.U
+        G = LULinv{Float64}(F)
+        @test A * G.L ≈ G.L * G.U
     end
 end

--- a/test/test_lulinv.jl
+++ b/test/test_lulinv.jl
@@ -1,0 +1,82 @@
+using LinearAlgebra, MatrixFactorizations, Random, Test
+
+@testset "A = LUL⁻¹" begin
+    @testset "A::Matrix{Int}" begin
+        V = [2 3 16; 1 -1 5; 0 1 1//1]
+        λ = [17//1; -2; 3]
+        A = det(V)*V*Diagonal(λ)/V
+        @test A == Matrix{Int}(A)
+        L, U = lulinv(A, λ)
+        @test A ≈ L*U/L
+        @test A*L ≈ L*U
+    end
+    @testset "A::Matrix{Rational{Int}}" begin
+        Random.seed!(0)
+        V = rand(-3:3//1, 5, 5)
+        λ = [-2; -1; 0; 1; 2//1]
+        A = V*Diagonal(λ)/V
+        L, U = lulinv(A, λ)
+        @test A ≈ L*U/L
+        @test A*L ≈ L*U
+    end
+    @testset "Full Jordan blocks" begin
+        Random.seed!(0)
+        V = rand(-3:3//1, 5, 5)
+        λ = [-2; -2; 1; 1; 1//1]
+        J = diagm(0=> λ)
+        J[1, 2] = 1
+        J[3, 4] = 1
+        J[4, 5] = 1
+        A = V*J/V
+        L, U = lulinv(A, λ)
+        @test A ≈ L*U/L
+        @test A*L ≈ L*U
+    end
+    @testset "Alg ≠ geo" begin
+        Random.seed!(0)
+        V = rand(-3:3//1, 5, 5)
+        λ = [-2; -2; 1; 1; 1//1]
+        J = diagm(0 => λ)
+        J[1, 2] = 1
+        J[3, 4] = 1
+        A = V*J/V
+        L, U = lulinv(A, λ)
+        @test A ≈ L*U/L
+        @test A*L ≈ L*U
+        λ = [1; -2; -2; 1; 1//1]
+        L, U = lulinv(A, λ)
+        @test A ≈ L*U/L
+        @test A*L ≈ L*U
+        λ = [1; -2; 1; -2; 1//1]
+        L, U = lulinv(A, λ)
+        @test A ≈ L*U/L
+        @test A*L ≈ L*U
+    end
+    @testset "Index scan is correct" begin
+        Random.seed!(0)
+        V = rand(-3:3//1, 8, 8)
+        J1 = diagm(0 => 1//1*ones(Int, 4), 1 => rand(0:1, 3))
+        J2 = diagm(0 => -1//1*ones(Int, 4), 1 => rand(0:1, 3))
+        J = [J1 zeros(Rational{Int}, size(J1)); zeros(Rational{Int}, size(J2)) J2]
+        λ = diag(J)
+        A = V*J/V
+        L, U = lulinv(A, λ)
+        @test A ≈ L*U/L
+        @test A*L ≈ L*U
+    end
+    @testset "A::Matrix{Float64}" begin
+        A = [4.0 3; 6 3]
+        L, U = lulinv(A)
+        @test A ≈ L*U/L
+        @test A*L ≈ L*U
+        F = lulinv(A)
+        @test F\A ≈ I
+        @test A/F ≈ I
+        @test det(A) ≈ det(F)
+        @test_throws DomainError logdet(F)
+        lad, sd = logabsdet(A)
+        lad1, sd1 = logabsdet(F)
+        @test lad ≈ lad1
+        @test sd ≈ sd1
+    end
+end

--- a/test/test_lulinv.jl
+++ b/test/test_lulinv.jl
@@ -69,7 +69,12 @@ using LinearAlgebra, MatrixFactorizations, Random, Test
         L, U = lulinv(A)
         @test A ≈ L*U/L
         @test A*L ≈ L*U
+    end
+    @testset "size, det, logdet, logabsdet" begin
+        A = [4.0 3; 6 3]
         F = lulinv(A)
+        @test size(A) == size(F)
+        @test size(F, 1) == size(F, 2)
         @test F\A ≈ I
         @test A/F ≈ I
         @test det(A) ≈ det(F)
@@ -78,5 +83,32 @@ using LinearAlgebra, MatrixFactorizations, Random, Test
         lad1, sd1 = logabsdet(F)
         @test lad ≈ lad1
         @test sd ≈ sd1
+    end
+    @testset "REPL printing" begin
+            bf = IOBuffer()
+            show(bf, "text/plain", lulinv([2 1; 1 2]))
+            seekstart(bf)
+            @test String(take!(bf)) ==
+"""
+LULinv{Float64, Matrix{Float64}}
+L factor:
+2×2 Matrix{Float64}:
+  1.0  0.0
+ -1.0  1.0
+U factor:
+2×2 Matrix{Float64}:
+ 1.0  1.0
+ 0.0  3.0"""
+    end
+    @testset "propertynames" begin
+        names = sort!(collect(string.(Base.propertynames(lulinv([2 1; 1 2])))))
+        @test names == ["L", "U"]
+        allnames = sort!(collect(string.(Base.propertynames(lulinv([2 1; 1 2]), true))))
+        @test allnames == ["L", "U", "factors"]
+    end
+    @testset "A::Matrix{Int64}, λ::Vector{Rational{Int64}}" begin
+        A = [-150 334 778; -89 195 464; 5 -10 -27]
+        F = lulinv(A, [17, -2, 3//1])
+        @test A * F.L == F.L * F.U
     end
 end


### PR DESCRIPTION
Every square matrix has one!

Can succeed in rational arithmetic with rational eigenvalues

```julia
julia> using MatrixFactorizations

julia> A = [-150 334 778; -89 195 464; 5 -10 -27]
3×3 Matrix{Int64}:
 -150  334  778
  -89  195  464
    5  -10  -27

julia> F = lulinv(A, [17, -2, 3//1])
LULinv{Rational{Int64}, Matrix{Rational{Int64}}}
L factor:
3×3 Matrix{Rational{Int64}}:
  1      0    0
 1//2    1    0
  0    -2//5  1
U factor:
3×3 Matrix{Rational{Int64}}:
 17  114//5  778
  0    -2     75
  0     0      3

julia> A*F.L == F.L*F.U
true

```