### PR TITLE
Add the Jordan canonical form

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MatrixFactorizations"
 uuid = "a3b82374-2e81-5b9e-98ce-41277c0e4c87"
-version = "3.1.2"
+version = "3.1.3"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ MatrixFactorizations.QL{Float64,Array{Float64,2}}
 Q factor:
 5×5 MatrixFactorizations.QLPackedQ{Float64,Array{Float64,2}}:
   0.155574  -0.112555   -0.686362   -0.701064   0.0233276
-  0.363037  -0.0583277  -0.0329428   0.152682   0.916736 
- -0.670742   0.294355   -0.547867    0.347157   0.206843 
- -0.61094   -0.566041    0.324432   -0.353128   0.276396 
-  0.144425  -0.759527   -0.349868    0.489877  -0.199681 
+  0.363037  -0.0583277  -0.0329428   0.152682   0.916736
+ -0.670742   0.294355   -0.547867    0.347157   0.206843
+ -0.61094   -0.566041    0.324432   -0.353128   0.276396
+  0.144425  -0.759527   -0.349868    0.489877  -0.199681
 L factor:
 5×5 Array{Float64,2}:
  -1.75734     0.0         0.0        0.0       0.0   
@@ -36,5 +36,37 @@ L factor:
   1.08725     0.746217    0.549688  -1.10194  -2.0581
 
 julia> b = randn(5); ql(A) \ b ≈ A \ b
+true
+```
+
+## Jordan canonical form
+
+Every square matrix has a Jordan canonical form. Although Jordan blocks are unstable
+with respect to perturbations, the Jordan canonical form of a rational matrix with
+rational eigenvalues can be found exactly:
+```julia
+
+julia> A = [0 0 1 7 -1; -5 -6 -6 -35 5; 1 1 -7 7 -1; 0 0 0 -9 0; 2 1 -5 -42 -3];
+
+julia> λ = [-9, -7, -7, -1, -1//1];
+
+julia> V, J = jordan(A, λ)
+Jordan{Rational{Int64}, Matrix{Rational{Int64}}, Matrix{Rational{Int64}}}
+Generalized eigenvectors:
+5×5 Matrix{Rational{Int64}}:
+ 0  0   0  1   0
+ 0  1   0  0  -1
+ 0  1  -1  0   0
+ 1  0   0  0   0
+ 7  1  -1  1  -1
+Jordan normal form:
+5×5 Matrix{Rational{Int64}}:
+ -9   0   0   0   0
+  0  -7   1   0   0
+  0   0  -7   0   0
+  0   0   0  -1   1
+  0   0   0   0  -1
+
+julia> A == V*J/V
 true
 ```

--- a/src/MatrixFactorizations.jl
+++ b/src/MatrixFactorizations.jl
@@ -34,7 +34,7 @@ import ArrayLayouts: reflector!, reflectorApply!, materialize!, @_layoutlmul, @_
 
 export ul, ul!, ql, ql!, qrunblocked, qrunblocked!, UL, QL,
     reversecholesky, reversecholesky!, ReverseCholesky,
-    lulinv, lulinv!, LULinv
+    lulinv, lulinv!, LULinv, jordan, Jordan
 
 const AdjointQtype = isdefined(LinearAlgebra, :AdjointQ) ? LinearAlgebra.AdjointQ : Adjoint
 const AbstractQtype = AbstractQ <: AbstractMatrix ? AbstractMatrix : AbstractQ
@@ -125,5 +125,6 @@ include("rq.jl")
 include("polar.jl")
 include("reversecholesky.jl")
 include("lulinv.jl")
+include("jordan.jl")
 
 end #module

--- a/src/jordan.jl
+++ b/src/jordan.jl
@@ -1,0 +1,279 @@
+"""
+    Jordan <: Factorization
+
+Jordan canonical form of a square matrix `A = VJV⁻¹`. This
+is the return type of [`jordan`](@ref), the corresponding Jordan factorization function.
+
+The individual components of the factorization `F::Jordan` can be accessed via [`getfield`](@ref):
+
+| Component | Description                  |
+|:----------|:-----------------------------|
+| `F.V`     | `V` generalized eigenvectors |
+| `F.J`     | `J` Jordan normal form       |
+
+Iterating the factorization produces the components `F.V` and `F.J`.
+
+# Examples
+```jldoctest
+julia> A = [5 4 2 1; 0 1 -1 -1; -1 -1 3 0; 1 1 -1 2//1]
+
+julia> λ = [1, 2, 4, 4//1] # you will almost certainly need extremely accurate eigenvalues to proceed
+
+julia> F = jordan(A, λ)
+Jordan{Rational{Int64}, Matrix{Rational{Int64}}, Matrix{Rational{Int64}}}
+Generalized eigenvectors:
+4×4 Matrix{Rational{Int64}}:
+  1   1  -1  -1
+ -1  -1   0   0
+  0   0   1   0
+  0   1  -1   0
+Jordan normal form:
+4×4 Matrix{Rational{Int64}}:
+ 1  0  0  0
+ 0  2  0  0
+ 0  0  4  1
+ 0  0  0  4
+
+julia> A*F.V == F.V*F.J
+true
+
+julia> V, J = jordan(A, λ); # destructuring via iteration
+
+julia> V == F.V && J == F.J
+true
+```
+"""
+struct Jordan{T, R <: AbstractMatrix{T}, S <: AbstractMatrix{T}} <: Factorization{T}
+    V::R
+    J::S
+end
+
+Jordan{T}(V::AbstractMatrix, J::AbstractMatrix) where T = Jordan(convert(AbstractMatrix{T}, V), convert(AbstractMatrix{T}, J))
+Jordan{T}(F::Jordan) where T = Jordan{T}(F.V, F.J)
+
+iterate(F::Jordan) = (F.V, Val(:J))
+iterate(F::Jordan, ::Val{:J}) = (F.J, Val(:done))
+iterate(F::Jordan, ::Val{:done}) = nothing
+
+function show(io::IO, mime::MIME{Symbol("text/plain")}, F::Jordan)
+    summary(io, F); println(io)
+    println(io, "Generalized eigenvectors:")
+    show(io, mime, F.V)
+    println(io, "\nJordan normal form:")
+    show(io, mime, F.J)
+end
+
+# dangerous because Jordan blocks are unstable with respect to small perturbations
+jordan(A::AbstractMatrix) = jordan(A, eigvals(A))
+
+function jordan(A::AbstractMatrix{S}, λ::AbstractVector{T}) where {S, T}
+    V = promote_type(S, T)
+    jordan(convert(AbstractMatrix{V}, A), convert(AbstractVector{V}, λ))
+end
+
+function jordan(A::AbstractMatrix{T}, λ::AbstractVector{T}) where T
+    PLEP, B = block_diagonalize(A, λ)
+    F, J = block_diagonal_to_jordan(B)
+    V = PLEP*F
+    return Jordan(V, J)
+end
+
+function triangular_to_psychologically_block_diagonal(U::UpperTriangular{T, <: AbstractMatrix{T}}) where T
+    n = checksquare(U)
+    R = deepcopy(U)
+    EACC = UpperTriangular(Matrix{T}(I, n, n))
+    # note that this is sensitive to the order of conjugation.
+    for j in 2:n
+        for i in j-1:-1:1
+            if R[i, i] != R[j, j]
+                E = UpperTriangular(Matrix{T}(I, n, n))
+                E[i, j] = R[i, j]/(R[j, j] - R[i, i])
+                R = E\R*E
+                EACC = EACC*E
+            end
+        end
+    end
+    return EACC, R
+end
+
+function psychologically_block_diagonal_to_block_diagonal(R::UpperTriangular{T, <: AbstractMatrix{T}}) where T
+    p = sortperm(diag(R))
+    n = length(p)
+    P = Matrix{Int}(I, n, n)[:, p]
+    B = R[p, p]
+    P, B
+end
+
+function triangular_to_block_diagonal(U::UpperTriangular{T, <: AbstractMatrix{T}}) where T
+    E, R = triangular_to_psychologically_block_diagonal(U)
+    p = sortperm(diag(R))
+    E[:, p], R[p, p]
+end
+
+function block_diagonalize(A::AbstractMatrix{T}, λ::AbstractVector{T}) where T
+    F = lulinv(A, λ)
+    PLEP, B = triangular_to_block_diagonal(UpperTriangular(F.factors))
+    lmul!(UnitLowerTriangular(F.factors), PLEP)
+    F.P*PLEP, B
+end
+
+function determine_block_sizes(B::AbstractMatrix{T}) where T
+    n = checksquare(B)
+    if n == 1
+        m = [1]
+        return m
+    else
+        m = Int[]
+        i = 1
+        while i < n
+            t = 1
+            while (i < n-1) && (B[i, i] == B[i+1, i+1])
+                i += 1
+                t += 1
+            end
+            if i == n-1
+                if B[i, i] == B[i+1, i+1]
+                    t += 1
+                    push!(m, t)
+                else
+                    push!(m, t)
+                    push!(m, 1)
+                end
+            else
+                push!(m, t)
+            end
+            i += 1
+        end
+        return m
+    end
+end
+
+function block_diagonal_to_jordan(B::Matrix{T}) where T
+    n = checksquare(B)
+    m = determine_block_sizes(B)
+    cm = cumsum(m)
+    pushfirst!(cm, 0)
+    F = zeros(T, n, n)
+    J = zeros(T, n, n)
+    for i in 1:length(m)
+        ir = cm[i]+1:cm[i+1]
+        FB, JB = upper_triangular_block_to_jordan_blocks(B[ir, ir])
+        F[ir, ir] .= FB
+        J[ir, ir] .= JB
+    end
+    return F, J
+end
+
+# Contract: B_{i, j} = 0 for i > j. B_{i, i} = B_{j, j} for all i ≠ j.
+function upper_triangular_block_to_jordan_blocks(B::Matrix{T}) where T
+    n = checksquare(B)
+    J = deepcopy(B)
+    FACC = Matrix{T}(I, n, n)
+    for j in 2:n
+        # In column j, we shall introduce zeros in any row with a 1 in the {i, i+1} position.
+        F = Matrix{T}(I, n, n)
+        for i in 1:j-2
+            if !iszero(J[i, i+1])
+                F[i+1, j] = -J[i, j]
+            end
+        end
+        J = F\J*F
+        FACC = FACC*F
+        while count(!iszero, J[1:j-1, j]) > 1
+            # Next, we identify the first and next nonzeros in the last column. By the first step, they are across from the last row of a Jordan block.
+            i1 = 1
+            while i1 < j
+                if !iszero(J[i1, j])
+                    break
+                else
+                    i1 += 1
+                end
+            end
+            i2 = i1+1
+            while i2 < j
+                if !iszero(J[i2, j])
+                    break
+                else
+                    i2 += 1
+                end
+            end
+            # With i1 and i2, we find the sizes of the corresponding Jordan blocks, s and t.
+            i1s = i1
+            while i1s > 1
+                if iszero(J[i1s-1, i1s])
+                    break
+                else
+                    i1s -= 1
+                end
+            end
+            i2s = i2
+            while i2s > 1
+                if iszero(J[i2s-1, i2s])
+                    break
+                else
+                    i2s -= 1
+                end
+            end
+            i1r = i1s:i1
+            i2r = i2s:i2
+            s = length(i1r)
+            t = length(i2r)
+            # Eliminate one of the nonzeros or the other.
+            if s ≤ t
+                # eliminate α
+                F = Matrix{T}(I, n, n)
+                α = J[i1, j]
+                β = J[i2, j]
+                γ = α/β
+                F[i1r, i2-s+1:i2] .= Matrix{T}(γ*I, s, s)
+                J = F\J*F
+                FACC = FACC*F
+            else
+                # eliminate β
+                F = Matrix{T}(I, n, n)
+                α = J[i1, j]
+                β = J[i2, j]
+                γ = β/α
+                F[i2r, i1-t+1:i1] .= Matrix{T}(γ*I, t, t)
+                J = F\J*F
+                FACC = FACC*F
+            end
+        end
+        # Next, we must permute to get the final nonzero to the bottom, if there is one at all.
+        i1 = 1
+        while i1 < j
+            if !iszero(J[i1, j])
+                break
+            else
+                i1 += 1
+            end
+        end
+        if i1 < j-1
+            # With i1, we find the size of the corresponding Jordan block, s.
+            i1s = i1
+            while i1s > 1
+                if iszero(J[i1s-1, i1s])
+                    break
+                else
+                    i1s -= 1
+                end
+            end
+            i1r = i1s:i1
+            s = length(i1r)
+            p = [1:i1s-1; i1+1:j-1; i1r; j:n]
+            #P = Matrix{T}(I, n, n)[:, p]
+            #J = P'J*P
+            #FACC = FACC*P
+            J = J[p, p]
+            FACC = FACC[:, p]
+        end
+        # Finally, we must scale off the nonzero entry to 1 to get it to conform to a Jordan block.
+        if !iszero(J[j-1, j])
+            F = Matrix{T}(I, n, n)
+            F[j, j] = inv(J[j-1, j])
+            J = F\J*F
+            FACC = FACC*F
+        end
+    end
+    return FACC, J
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,5 +37,6 @@ include("test_rq.jl")
 include("test_polar.jl")
 include("test_reversecholesky.jl")
 include("test_lulinv.jl")
+include("test_jordan.jl")
 
 include("test_banded.jl")

--- a/test/test_jordan.jl
+++ b/test/test_jordan.jl
@@ -1,0 +1,272 @@
+using LinearAlgebra, MatrixFactorizations, Random, Test
+
+@testset "Jordan Canonical Form" begin
+    Random.seed!(0)
+    V = rand(-3:3//1, 5, 5)
+    λ = [1; 1; 1; -2; -2//1]
+    J = diagm(0 => λ)
+    J[1, 2] = 1
+    #J[3, 4] = 1
+    J[4, 5] = 1
+    A = V*J/V
+    F = lulinv(A, λ)
+    L, U, p = F.L, F.U, F.p
+    @test A[p, p] ≈ L*U/L
+    E, R = MatrixFactorizations.triangular_to_psychologically_block_diagonal(UpperTriangular(U))
+    @test U ≈ E*R/E
+    P, B = MatrixFactorizations.psychologically_block_diagonal_to_block_diagonal(R)
+    @test R ≈ P*B*P'
+    EP, B = MatrixFactorizations.triangular_to_block_diagonal(UpperTriangular(U))
+    @test U ≈ EP*B/EP
+    PLEP, B = MatrixFactorizations.block_diagonalize(A, λ)
+    @test A ≈ PLEP*B/PLEP
+
+    @testset "Block sizes" begin
+        import MatrixFactorizations: determine_block_sizes
+        m = determine_block_sizes([1;;])
+        @test m == [1]
+        m = determine_block_sizes([1 2; 3 4])
+        @test m == [1, 1]
+        m = determine_block_sizes([1 2; 3 1])
+        @test m == [2]
+        m = determine_block_sizes([1 2 3;0 1 4; 0 0 1])
+        @test m == [3]
+        m = determine_block_sizes([1 2 3;0 2 4; 0 0 2])
+        @test m == [1, 2]
+        m = determine_block_sizes([2 2 3;0 2 4; 0 0 1])
+        @test m == [2, 1]
+        m = determine_block_sizes([1 2 3;0 2 4; 0 0 3])
+        @test m == [1, 1, 1]
+        m = determine_block_sizes([1 2 3 4;0 2 5 6; 0 0 3 7; 0 0 0 4])
+        @test m == [1, 1, 1, 1]
+        m = determine_block_sizes([1 2 3 4;0 2 5 6; 0 0 3 7; 0 0 0 3])
+        @test m == [1, 1, 2]
+        m = determine_block_sizes([1 2 3 4;0 2 5 6; 0 0 2 7; 0 0 0 3])
+        @test m == [1, 2, 1]
+        m = determine_block_sizes([1 2 3 4;0 3 5 6; 0 0 3 7; 0 0 0 3])
+        @test m == [1, 3]
+        m = determine_block_sizes([3 2 3 4;0 3 5 6; 0 0 3 7; 0 0 0 3])
+        @test m == [4]
+        m = determine_block_sizes([1 2 3 4;0 1 5 6; 0 0 3 7; 0 0 0 4])
+        @test m == [2, 1, 1]
+        m = determine_block_sizes([1 2 3 4;0 1 5 6; 0 0 3 7; 0 0 0 3])
+        @test m == [2, 2]
+        m = determine_block_sizes([1 2 3 4;0 1 5 6; 0 0 1 7; 0 0 0 3])
+        @test m == [3, 1]
+        m = determine_block_sizes(UpperTriangular([1 2 3 4;0 1 5 6; 0 0 1 7; 0 0 0 3]))
+        @test m == [3, 1]
+        Random.seed!(0)
+        m = determine_block_sizes(rand(0:1, 10, 10))
+        @test m == [1, 2, 2, 2, 1, 1, 1]
+        m = determine_block_sizes(rand(0:1, 20, 20))
+        @test m == [1, 3, 4, 6, 2, 2, 1, 1]
+    end
+
+    @testset "Upper triangular block to Jordan blocks" begin
+        import MatrixFactorizations: upper_triangular_block_to_jordan_blocks
+        Random.seed!(0)
+        B = diagm(0 => 3//1*ones(Int, 12), 1 => [1,1,0,1,1,0,1,0,1,1,0]) + rand(-3:3, 12)*[zeros(Int,11); 1]'; B[end] = 3; B
+        F, J = upper_triangular_block_to_jordan_blocks(B)
+        @test B ≈ F*J/F
+
+        B = diagm(0 => 4//1*ones(Int, 12)) + triu!(rand(-4:4, 12, 12), 1)
+        F, J = upper_triangular_block_to_jordan_blocks(B)
+        @test B ≈ F*J/F
+
+        B = diagm(0 => 4//1*ones(Int, 12)) + triu!(rand(-4:4, 12, 12), 1)
+        B = Rational{BigInt}.(B)
+        F, J = upper_triangular_block_to_jordan_blocks(B)
+        @test B ≈ F*J/F
+
+        B = diagm(0 => 4//1*ones(Int, 12)) + triu!(rand(-4:4, 12, 12), 1)
+        F, J = upper_triangular_block_to_jordan_blocks(B)
+        @test B ≈ F*J/F
+
+        B = [2 1 2; 0 2 1; 0 0 2//1]
+        F, J = upper_triangular_block_to_jordan_blocks(B)
+        @test B ≈ F*J/F
+
+        B = [2 1 4 0; 0 2 1 0; 0 0 2 0; 0 0 0 2//1]
+        F, J = upper_triangular_block_to_jordan_blocks(B)
+        @test B ≈ F*J/F
+
+        B = [2 1 4 0; 0 2 1 -1; 0 0 2 1; 0 0 0 2//1]
+        F, J = upper_triangular_block_to_jordan_blocks(B)
+        @test B ≈ F*J/F
+
+        F = Matrix{Rational{Int}}(triu!(rand(1:4, 12, 12)))
+        J = diagm(0 => 4//1*ones(Int, 12), 1 => rand(0:1, 11))
+        B = Matrix{Rational{BigInt}}(F*J/F)
+        F, J = upper_triangular_block_to_jordan_blocks(B)
+        @test B ≈ F*J/F
+    end
+
+    @testset "JCF" begin
+        Random.seed!(0)
+        for _ in 1:10
+            V = rand(-3:3//1, 8, 8)
+            J1 = diagm(0 => 1//1*ones(Int, 4), 1 => rand(0:1, 3))
+            J2 = diagm(0 => -1//1*ones(Int, 4), 1 => rand(0:1, 3))
+            J = [J1 zeros(Rational{Int}, size(J1)); zeros(Rational{Int}, size(J2)) J2]
+            λ = diag(J)
+            A = V*J/V
+            V, J = jordan(A, λ)
+            @test A*V ≈ V*J
+        end
+    end
+
+    @testset "Jordan canonical forms in the wild" begin
+        @testset "https://en.wikipedia.org/wiki/Jordan_normal_form" begin
+            A = [5 4 2 1; 0 1 -1 -1; -1 -1 3 0; 1 1 -1 2//1]
+            λ = [1, 2, 4, 4//1]
+            @test λ ≈ eigvals(A)
+            V, J = jordan(A, λ)
+            @test A*V == V*J
+            # Next step in this code would be to completely elucidate the block structure in J:
+            #JCF = BlockArrays.BlockDiagonal([JordanBlock(1//1, 1), JordanBlock(2//1, 1), JordanBlock(4//1, 2)])
+            #@test J == JCF
+        end
+        @testset "https://math.stackexchange.com/questions/1221465/jordan-canonical-form-deployment" begin
+            A = [-3 1 0 1 1; -3 1 0 1 1; -4 1 0 2 1; -3 1 0 1 1; -4 1 0 1 2//1]
+            λ = [0, 0, 0, 0, 1//1]
+            @test λ ≈ eigvals(A)
+            V, J = jordan(A, λ)
+            @test A*V == V*J
+        end
+        @testset "https://math.stackexchange.com/questions/3627150/find-the-jordan-form" begin
+            A = [-83 -15 -68 -2 -100 216; -3 1 -2 0 -4 9; 42 7 35 1 50 -108; 43 8 35 3 50 -108; 22 4 18 1 27 -54; -10 -2 -8 0 -12 28//1]
+            λ = [1, 2, 2, 2, 2, 2//1]
+            @test all(det(A-λ[j]*I) == 0 for j in 1:length(λ))
+            V, J = jordan(A, λ)
+            @test A*V == V*J
+        end
+        @testset "https://www.maplesoft.com/applications/preview.aspx?id=33195" begin
+            A = [-10 -13 15 -16 6 9 -3; 4 5 -6 7 -2 -4 1; -50 -60 72 -77 29 43 -13; -82 -98 118 -127 47 71 -21; 2 1 -2 2 -1 -1 0; -56 -66 80 -86 32 48 -14; 48 59 -70 75 -28 -42 13//1]
+            λ = zeros(Rational{Int}, 7)
+            V, J = jordan(A, λ)
+            @test A*V == V*J
+        end
+        @testset "https://askfilo.com/user-question-answers-smart-solutions/find-the-jordan-canonical-form-j-for-the-matrix-also-find-a-3337353836383137" begin
+            A = [-1 0 -2 -4; 2 1 2 4; -4 2 -1 -4; 2 -1 1 3//1]
+            λ = [-1, 1, 1, 1//1]
+            V, J = jordan(A, λ)
+            @test A*V == V*J
+        end
+        @testset "https://www.bartleby.com/questions-and-answers/1.-find-the-jordan-canonical-form-for-the-following-matrices.-0-0-0-0-1-2-0-4-a.-v-2.-1.-1-2-0.-0-0-/2193cc71-c370-45ea-bfed-d5cfe17c8946" begin
+            B = [0 1 0 0; -3 4 0 0; 2 -1 2 0; -1 1 1 2//1]
+            λ = [1, 2, 2, 3//1]
+            V, J = jordan(B, λ)
+            @test B*V == V*J
+            A = [1 0 0 0 0; 1 -1 0 0 -1; 1 -1 0 0 -1; 0 0 0 0 -1; -1 1 0 0 1//1]
+            λ = [0, 0, 0, 0, 1//1]
+            V, J = jordan(A, λ)
+            @test A*V == V*J
+        end
+        @testset "http://buzzard.ups.edu/courses/2014spring/420demos/JCF-demo.pdf" begin
+            A = Rational{BigInt}[50 -10 17 -21 7 6 1 -37 -8 -10 10 -14 27 39 8;
+                 186 -207 -36 -184 -74 -71 -54 -22 -1 -93 38 -11 56 187 14;
+                 3 16 9 -10 -11 8 -4 -24 4 -6 2 -14 13 6 -2;
+                 -132 202 62 162 83 77 58 -23 -14 86 -28 -4 -22 -149 -3;
+                 213 -237 -41 -218 -94 -82 -65 -30 2 -111 45 -16 69 216 13;
+                 -608 549 27 552 195 173 139 178 34 266 -124 72 -239 -574 -57;
+                 253 -299 -57 -274 -125 -108 -83 -26 3 -137 52 -15 79 258 15;
+                 -196 175 0 170 50 56 38 58 21 76 -38 18 -76 -176 -23;
+                 704 -651 -40 -649 -233 -206 -167 -197 -35 -313 143 -80 272 668 64;
+                 322 -238 25 -251 -53 -62 -51 -126 -39 -112 62 -43 139 283 42;
+                 -536 411 -28 449 129 115 98 211 52 207 -105 79 -236 -482 -61;
+                 170 -190 -25 -165 -58 -67 -45 -20 -11 -77 32 -4 51 163 17;
+                 1 14 9 10 9 7 6 -7 -4 5 0 -1 7 -4 1;
+                 223 -195 -1 -201 -64 -61 -49 -71 -20 -92 43 -26 91 206 25;
+                 -58 4 -27 29 -7 -10 1 53 12 12 -11 20 -39 -45 -10]
+            λ = Rational{BigInt}[-ones(5); 2*ones(10)]
+            V, J = jordan(A, λ)
+            @test A*V == V*J
+        end
+        @testset "http://matrix.skku.ac.kr/2014-Album/JCF/2GEV_JCF_u_GEV.htm" begin
+            A = [0 0 1 7 -1; -5 -6 -6 -35 5; 1 1 -7 7 -1; 0 0 0 -9 0; 2 1 -5 -42 -3//1]
+            λ = [-9, -7, -7, -1, -1//1]
+            V, J = jordan(A, λ)
+            @test A*V == V*J
+        end
+        @testset "https://www.numerade.com/ask/question/1-find-a-jordan-canonical-form-of-the-following-matrix-4-1-0-0-a-h4ih-1-28093/" begin
+            A = [4 1 0 0 0; -1 3 1 0 0; 1 0 2 0 0; -2 -1 -1 2 1; 1 0 0 0 2//1]
+            λ = [2, 2, 3, 3, 3//1]
+            @test all(det(A-λ[j]*I) == 0 for j in 1:length(λ))
+            V, J = jordan(A, λ)
+            @test A*V == V*J
+        end
+        @testset "https://www.chegg.com/homework-help/questions-and-answers/3-find-jordan-canonical-form-j-following-matrices-determine-matrix-x-xax-j-11-0-1-1-2-0-0--q25805340" begin
+            A = [1 0 1; 1 0 2; 1 -1 2]
+            λ = [1, 1, 1]
+            @test all(det(A-λ[j]*I) == 0 for j in 1:length(λ))
+            V, J = jordan(A, λ)
+            @test A*V == V*J
+            A = [0 0 0 1; 0 0 0 1; 1 2 0 0; 0 0 0 -1.0]
+            V, J = jordan(A, eigvals(A))
+            @test A*V ≈ V*J
+            A = [1 2 0 0; 0 1 2 0; 0 0 1 2; 0 0 0 1//1]
+            λ = diag(A) # because A is upper triangular
+            V, J = jordan(A, λ)
+            @test A*V == V*J
+            A = [1 1 1 1 1; 0 1 1 1 1; 0 0 1 1 1; 0 0 0 0 1; 0 0 0 0 0//1]
+            λ = diag(A) # because A is upper triangular
+            V, J = jordan(A, λ)
+            @test A*V == V*J
+            A = [2 1 1 1 1 1; 0 2 1 1 1 1; 0 0 0 1 1 1; 0 0 0 0 1 1; 0 0 0 0 1 1; 0 0 0 0 1 1//1]
+            λ = Rational{Int}.(eigvals(A))
+            @test λ ≈ eigvals(A)
+            V, J = jordan(A, λ)
+            @test A*V == V*J
+        end
+        @testset "https://www.chegg.com/homework-help/questions-and-answers/solve-using-matlab-find-jordan-canonical-form-b-determine-matrix-diagonalizable-find-simil-q46775702" begin
+            A = [0 1 -1 2 1 -1; -4 3 -1 3 1 0; 0 1 1 3 -1 -2; 0 1 -1 4 0 -2; 0 1 -1 2 2 -2; -1 1 -1 2 1 0//1]
+            λ = [1, 1, 2, 2, 2, 2//1]
+            V, J = jordan(A, λ)
+            @test A*V == V*J
+        end
+        @testset "https://www.chegg.com/homework-help/questions-and-answers/question-2-calculate-jordan-canonical-form-matrix-0-0-0-2-0-0-0-2-0-0-2-1-0-0-1-0-1-1-1-1--q58058571" begin
+            A = [2 0 0 0 0 0; 0 2 0 0 0 0; 1 0 2 0 0 0; -1 0 0 -3 0 0; -1 0 1 1 -3 0; -1 1 -1 1 -1 -3//1]
+            λ = diag(A) # because A is lower triangular
+            V, J = jordan(A, λ)
+            @test A*V == V*J
+        end
+    end
+
+    @testset "REPL printing" begin
+            bf = IOBuffer()
+            show(bf, "text/plain", jordan([1 0; 0 1]))
+            seekstart(bf)
+            @test String(take!(bf)) ==
+"""
+Jordan{Float64, Matrix{Float64}, Matrix{Float64}}
+Generalized eigenvectors:
+2×2 Matrix{Float64}:
+ 0.0  1.0
+ 1.0  0.0
+Jordan normal form:
+2×2 Matrix{Float64}:
+ 1.0  0.0
+ 0.0  1.0"""
+    end
+
+    @testset "propertynames" begin
+        names = sort!(collect(string.(Base.propertynames(jordan([2 1; 1 2])))))
+        @test names == ["J", "V"]
+        allnames = sort!(collect(string.(Base.propertynames(jordan([2 1; 1 2]), true))))
+        @test allnames == ["J", "V"]
+    end
+
+    @testset "Mixed input types, conversion" begin
+        A = [0 0 1 7 -1; -5 -6 -6 -35 5; 1 1 -7 7 -1; 0 0 0 -9 0; 2 1 -5 -42 -3//1]
+        λ = [-9, -7, -7, -1, -1]
+        V, J = jordan(A, λ)
+        @test A*V == V*J
+        A = [0 0 1 7 -1; -5 -6 -6 -35 5; 1 1 -7 7 -1; 0 0 0 -9 0; 2 1 -5 -42 -3]
+        λ = [-9, -7, -7, -1, -1//1]
+        V, J = jordan(A, λ)
+        @test A*V == V*J
+        F = jordan(A, λ)
+        G = Jordan{Float64}(F)
+        @test A*G.V ≈ G.V*G.J
+    end
+end

--- a/test/test_jordan.jl
+++ b/test/test_jordan.jl
@@ -119,7 +119,6 @@ using LinearAlgebra, MatrixFactorizations, Random, Test
         @testset "https://en.wikipedia.org/wiki/Jordan_normal_form" begin
             A = [5 4 2 1; 0 1 -1 -1; -1 -1 3 0; 1 1 -1 2//1]
             λ = [1, 2, 4, 4//1]
-            @test λ ≈ eigvals(A)
             V, J = jordan(A, λ)
             @test A*V == V*J
             # Next step in this code would be to completely elucidate the block structure in J:
@@ -129,14 +128,12 @@ using LinearAlgebra, MatrixFactorizations, Random, Test
         @testset "https://math.stackexchange.com/questions/1221465/jordan-canonical-form-deployment" begin
             A = [-3 1 0 1 1; -3 1 0 1 1; -4 1 0 2 1; -3 1 0 1 1; -4 1 0 1 2//1]
             λ = [0, 0, 0, 0, 1//1]
-            @test λ ≈ eigvals(A)
             V, J = jordan(A, λ)
             @test A*V == V*J
         end
         @testset "https://math.stackexchange.com/questions/3627150/find-the-jordan-form" begin
             A = [-83 -15 -68 -2 -100 216; -3 1 -2 0 -4 9; 42 7 35 1 50 -108; 43 8 35 3 50 -108; 22 4 18 1 27 -54; -10 -2 -8 0 -12 28//1]
             λ = [1, 2, 2, 2, 2, 2//1]
-            @test all(det(A-λ[j]*I) == 0 for j in 1:length(λ))
             V, J = jordan(A, λ)
             @test A*V == V*J
         end
@@ -191,18 +188,16 @@ using LinearAlgebra, MatrixFactorizations, Random, Test
         @testset "https://www.numerade.com/ask/question/1-find-a-jordan-canonical-form-of-the-following-matrix-4-1-0-0-a-h4ih-1-28093/" begin
             A = [4 1 0 0 0; -1 3 1 0 0; 1 0 2 0 0; -2 -1 -1 2 1; 1 0 0 0 2//1]
             λ = [2, 2, 3, 3, 3//1]
-            @test all(det(A-λ[j]*I) == 0 for j in 1:length(λ))
             V, J = jordan(A, λ)
             @test A*V == V*J
         end
         @testset "https://www.chegg.com/homework-help/questions-and-answers/3-find-jordan-canonical-form-j-following-matrices-determine-matrix-x-xax-j-11-0-1-1-2-0-0--q25805340" begin
             A = [1 0 1; 1 0 2; 1 -1 2]
             λ = [1, 1, 1]
-            @test all(det(A-λ[j]*I) == 0 for j in 1:length(λ))
             V, J = jordan(A, λ)
             @test A*V == V*J
             A = [0 0 0 1; 0 0 0 1; 1 2 0 0; 0 0 0 -1.0]
-            V, J = jordan(A, eigvals(A))
+            V, J = jordan(A)
             @test A*V ≈ V*J
             A = [1 2 0 0; 0 1 2 0; 0 0 1 2; 0 0 0 1//1]
             λ = diag(A) # because A is upper triangular


### PR DESCRIPTION
This enables
```julia
julia> using MatrixFactorizations

julia> A = [0 0 1 7 -1; -5 -6 -6 -35 5; 1 1 -7 7 -1; 0 0 0 -9 0; 2 1 -5 -42 -3]
5×5 Matrix{Int64}:
  0   0   1    7  -1
 -5  -6  -6  -35   5
  1   1  -7    7  -1
  0   0   0   -9   0
  2   1  -5  -42  -3

julia> λ = [-9, -7, -7, -1, -1//1]
5-element Vector{Rational{Int64}}:
 -9
 -7
 -7
 -1
 -1

julia> V, J = jordan(A, λ)
Jordan{Rational{Int64}, Matrix{Rational{Int64}}, Matrix{Rational{Int64}}}
Generalized eigenvectors:
5×5 Matrix{Rational{Int64}}:
 0  0   0  1   0
 0  1   0  0  -1
 0  1  -1  0   0
 1  0   0  0   0
 7  1  -1  1  -1
Jordan normal form:
5×5 Matrix{Rational{Int64}}:
 -9   0   0   0   0
  0  -7   1   0   0
  0   0  -7   0   0
  0   0   0  -1   1
  0   0   0   0  -1

julia> A*V == V*J
true

```
Note that Jordan blocks are unstable with respect to perturbations in the matrix, so the code is generally best used with rational arithmetic (with matrices with rational eigenvalues), though general support is provided.

In the future, the Jordan normal form of the matrix could benefit from structuring as a `BlockDiagonal` matrix with a new type of `LayoutMatrix` to describe a `JordanBlock`, but this comes with the drawback of including other packages in the requirements. `exp(J::JordanBlock)` (and other matrix functions) is also an `UpperTriangularToeplitz` matrix, though this gets quite esoteric.